### PR TITLE
Updating the SDK fixes signature verification check issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aeternity/aepp-sdk": "7.0.0",
+    "@aeternity/aepp-sdk": "7.7.0",
     "aeproject-lib": "^2.1.1",
     "yarn": "1.21.1"
   }


### PR DESCRIPTION
Updating the SDK fixes the issue with signature verification due problem with the signature prefix in the older versions of the SDK.